### PR TITLE
No need for Mix

### DIFF
--- a/lib/openmaize/report.ex
+++ b/lib/openmaize/report.ex
@@ -51,11 +51,10 @@ defmodule Openmaize.Report do
   """
   def terminate(conn), do: conn |> put_private(:openmaize_skip, true) |> halt
 
-  defp redirect_to(%Plug.Conn{scheme: scheme, host: host} = conn, address, message) do
-    if Mix.env == :dev, do: host = host <> ":4000"
+  defp redirect_to(conn, address, message) do
     unless map_size(message) == 0, do: conn = send_message(conn, message)
     conn
-    |> put_resp_header("location", "#{scheme}://#{host}#{address}")
+    |> put_resp_header("location", address)
     |> send_resp(302, "") |> terminate
   end
 


### PR DESCRIPTION
Since exrm deployments usually don't include Mix and there's no reason to have Mix in production, I think doing this not only makes the port flexible, but also the host. The location header doesn't need to include those anyway unless you access the form from elsewhere, and in that case using the `Plug.Conn` values is wrong too.
