### PR TITLE
Fixes double decoding of email when confirming users.

### DIFF
--- a/lib/openmaize/confirm/base.ex
+++ b/lib/openmaize/confirm/base.ex
@@ -49,7 +49,7 @@ defmodule Openmaize.Confirm.Base do
     case Map.get(user_params, to_string(uniq)) do
       nil -> finalize(nil, conn, nil, mail_func)
       user_id ->
-        URI.decode_www_form(user_id)
+        user_id
         |> Config.db_module.find_user(uniq)
         |> check_key(key, key_expiry * 60, password)
         |> finalize(conn, user_id, mail_func)

--- a/test/openmaize/confirm_email_test.exs
+++ b/test/openmaize/confirm_email_test.exs
@@ -5,13 +5,13 @@ defmodule Openmaize.ConfirmEmailTest do
   import Ecto.Changeset
   alias Openmaize.{ConfirmEmail, TestRepo, User}
 
-  @valid_link "email=fred%40mail.com&key=lg8UXGNMpb5LUGEDm62PrwW8c20qZmIw"
+  @valid_link "email=fred%2B1%40mail.com&key=lg8UXGNMpb5LUGEDm62PrwW8c20qZmIw"
   @name_link "username=fred&key=lg8UXGNMpb5LUGEDm62PrwW8c20qZmIw"
   @invalid_link "email=wrong%40mail.com&key=lg8UXGNMpb5LUGEDm62PrwW8c20qZmIw"
   @incomplete_link "email=wrong%40mail.com"
 
   setup do
-    {:ok, _user} = TestRepo.get_by(User, email: "fred@mail.com")
+    {:ok, _user} = TestRepo.get_by(User, email: "fred+1@mail.com")
     |> change(%{confirmed_at: nil})
     |> Openmaize.Config.repo.update
     :ok
@@ -24,7 +24,7 @@ defmodule Openmaize.ConfirmEmailTest do
   end
 
   def user_confirmed do
-    user = TestRepo.get_by(User, email: "fred@mail.com")
+    user = TestRepo.get_by(User, email: "fred+1@mail.com")
     user.confirmed_at
   end
 

--- a/test/support/setup_db.exs
+++ b/test/support/setup_db.exs
@@ -3,7 +3,7 @@ defmodule Openmaize.SetupDB do
   alias Openmaize.{TestRepo, User}
 
   def add_users do
-    user1 = %{email: "fred@mail.com", username: "fred", role: "user", password: "mangoes&g0oseberries",
+    user1 = %{email: "fred+1@mail.com", username: "fred", role: "user", password: "mangoes&g0oseberries",
               confirmed_at: nil, confirmation_sent_at: Ecto.DateTime.utc, reset_sent_at: Ecto.DateTime.utc}
     user2 = %{email: "dim@mail.com", username: "dim", role: "user", password: "mangoes&g0oseberries",
               confirmed_at: nil, confirmation_sent_at: Ecto.DateTime.utc, reset_sent_at: Ecto.DateTime.utc}


### PR DESCRIPTION
Hello, this fixes #36 - it looks like `user_id` was being decoded twice, at least if you inspect it right before the affected line, it's already decoded.
