### PR TITLE
Allow custom crypto mod config

### DIFF
--- a/lib/openmaize/config.ex
+++ b/lib/openmaize/config.ex
@@ -5,14 +5,14 @@ defmodule Openmaize.Config do
   The following are valid configuration items.
 
 
-  | name               | type    | default  |
-  | :----------------- | :------ | -------: |
-  | user_model         | module  | N/A      |
-  | repo               | module  | N/A      |
-  | db_module          | module  | Openmaize.DB   |
-  | hash_name          | atom    | :password_hash |
-  | crypto_mod         | module  | Comeonin.Bcrypt  |
-  | password_strength  | keyword list | []  |
+  | name               | type         | default          |
+  | :----------------- | :----------- | ---------------: |
+  | user_model         | module       | N/A              |
+  | repo               | module       | N/A              |
+  | db_module          | module       | Openmaize.DB     |
+  | hash_name          | atom         | :password_hash   |
+  | crypto_mod         | module       | Comeonin.Bcrypt  |
+  | password_strength  | keyword list | []               |
 
   The values for user_model and repo should be module names.
   If, for example, your app is called Coolapp and your user

--- a/lib/openmaize/config.ex
+++ b/lib/openmaize/config.ex
@@ -30,7 +30,7 @@ defmodule Openmaize.Config do
         repo: Coolapp.Repo,
         db_module: Coolapp.DB,
         hash_name: :encrypted_password,
-        crypto_mod: :pbkdf2,
+        crypto_mod: Comeonin.Bcrypt,
         password_strength: [min_length: 12]
 
   """

--- a/lib/openmaize/config.ex
+++ b/lib/openmaize/config.ex
@@ -4,13 +4,14 @@ defmodule Openmaize.Config do
 
   The following are valid configuration items.
 
+
   | name               | type    | default  |
   | :----------------- | :------ | -------: |
   | user_model         | module  | N/A      |
   | repo               | module  | N/A      |
   | db_module          | module  | Openmaize.DB   |
   | hash_name          | atom    | :password_hash |
-  | crypto_mod         | atom    | :bcrypt  |
+  | crypto_mod         | module  | Comeonin.Bcrypt  |
   | password_strength  | keyword list | []  |
 
   The values for user_model and repo should be module names.
@@ -67,20 +68,16 @@ defmodule Openmaize.Config do
   end
 
   @doc """
-  The password hashing and checking algorithm. You can choose between
-  bcrypt and pbkdf2_sha512. Bcrypt is the default.
-
-  For more information about these two algorithms, see the documentation
-  for Comeonin.
+  The password hashing and checking algorithm. Bcrypt is the default.
+  You can supply any module.  Module must implement the following
+  functions:
+  hashpwsalt/1 hashes the password
+  dummy_checkpw/0 performs a hash and returns false
+  checkpw/2 given a password and a salt, returns if match
+  See Comeonin.Bcrypt for example.
   """
-  def get_crypto_mod do
-    case crypto_mod do
-      :pbkdf2 -> Comeonin.Pbkdf2
-      _ -> Comeonin.Bcrypt
-    end
-  end
-  defp crypto_mod do
-    Application.get_env(:openmaize, :crypto_mod, :bcrypt)
+  def crypto_mod do
+    Application.get_env(:openmaize, :crypto_mod, Comeonin.Bcrypt)
   end
 
   @doc """

--- a/lib/openmaize/db.ex
+++ b/lib/openmaize/db.ex
@@ -75,7 +75,7 @@ if Code.ensure_loaded?(Ecto) do
     will be added to the changeset.
 
     Comeonin.Bcrypt is the default hashing function, but this can be changed to
-    Comeonin.Pbkdf2 by setting the Config.crypto_mod value to :pbkdf2.
+    Comeonin.Pbkdf2 by setting the Config.crypto_mod value.
     """
     def add_password_hash(user, params) do
       (params[:password] || params["password"])
@@ -152,7 +152,7 @@ if Code.ensure_loaded?(Ecto) do
 
     defp add_hash_changeset({:ok, password}, user) do
       Ecto.Changeset.change(user, %{Config.hash_name =>
-                                     Config.get_crypto_mod.hashpwsalt(password)})
+                                     Config.crypto_mod.hashpwsalt(password)})
     end
     defp add_hash_changeset({:error, message}, user) do
       Ecto.Changeset.change(user, %{password: ""})
@@ -161,7 +161,7 @@ if Code.ensure_loaded?(Ecto) do
 
     defp reset_update_repo({:ok, password}, user) do
       Config.repo.transaction(fn ->
-        user = Ecto.Changeset.change(user, %{Config.hash_name => Config.get_crypto_mod.hashpwsalt(password)})
+        user = Ecto.Changeset.change(user, %{Config.hash_name => Config.crypto_mod.hashpwsalt(password)})
         |> Config.repo.update!
 
         Ecto.Changeset.change(user, %{reset_token: nil, reset_sent_at: nil})

--- a/lib/openmaize/login/base.ex
+++ b/lib/openmaize/login/base.ex
@@ -62,12 +62,12 @@ defmodule Openmaize.Login.Base do
   end
   defp get_params(user_params, uniq_func), do: uniq_func.(user_params)
 
-  defp check_pass(nil, _, _), do: Config.get_crypto_mod.dummy_checkpw
+  defp check_pass(nil, _, _), do: Config.crypto_mod.dummy_checkpw
   defp check_pass(%{confirmed_at: nil}, _, _),
     do: {:error, "You have to confirm your email address before continuing."}
   defp check_pass(user, password, hash_name) do
     %{^hash_name => hash} = user
-    Config.get_crypto_mod.checkpw(password, hash) and {:ok, user}
+    Config.crypto_mod.checkpw(password, hash) and {:ok, user}
   end
 
   defp handle_auth({:ok, %{id: id, otp_required: true}}, conn, {storage, uniq, _, _}) do

--- a/test/openmaize/db_test.exs
+++ b/test/openmaize/db_test.exs
@@ -2,7 +2,7 @@ defmodule Openmaize.DBTest do
   use ExUnit.Case
   use Plug.Test
 
-  alias Openmaize.{DB, TestRepo, User}
+  alias Openmaize.{DB, DummyCrypto, TestRepo, User}
 
   test "easy password results in an error being added to the changeset" do
     user = %{email: "bill@mail.com", username: "bill", role: "user", password: "easytoguess",
@@ -27,6 +27,15 @@ defmodule Openmaize.DBTest do
     changeset = DB.add_reset_token(user, "lg8UXGNMpb5LUGEDm62PrwW8c20qZmIw")
     assert changeset.changes.reset_token
     assert changeset.changes.reset_sent_at
+  end
+
+  test "hashes according to algorithm" do
+    Application.put_env(:openmaize, :crypto_mod, DummyCrypto)
+
+    changeset = %User{} |> User.auth_changeset(%{password: "g0g0g4dg3t!!"})
+    assert changeset.changes.password_hash == "dumb-g0g0g4dg3t!!-crypto"
+  after
+    Application.delete_env(:openmaize, :crypto_mod)
   end
 
 end

--- a/test/openmaize/db_test.exs
+++ b/test/openmaize/db_test.exs
@@ -29,6 +29,11 @@ defmodule Openmaize.DBTest do
     assert changeset.changes.reset_sent_at
   end
 
+  test "defaults to hashing password with bcrypt" do
+    changeset = %User{} |> User.auth_changeset(%{password: "g0g0g4dg3t!!"})
+    assert Comeonin.Bcrypt.checkpw("g0g0g4dg3t!!", changeset.changes.password_hash)
+  end
+
   test "hashes according to algorithm" do
     Application.put_env(:openmaize, :crypto_mod, DummyCrypto)
 

--- a/test/support/dummy_crypto.exs
+++ b/test/support/dummy_crypto.exs
@@ -1,0 +1,17 @@
+defmodule Openmaize.DummyCrypto do
+  @moduledoc """
+  A dummy crypto module for testing purposes
+  """
+
+  def hashpwsalt(password) do
+    "dumb-#{password}-crypto"
+  end
+
+  def dummy_checkpw do
+    false
+  end
+
+  def checkpw(password, salt) do
+    salt == hashpwsalt(password)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,7 @@ ExUnit.start()
 {:ok, _} = Application.ensure_all_started(:postgrex)
 {:ok, _} = Application.ensure_all_started(:openmaize_jwt)
 
+Code.require_file "support/dummy_crypto.exs", __DIR__
 Code.require_file "support/ecto_helper.exs", __DIR__
 Code.require_file "support/setup_db.exs", __DIR__
 Code.require_file "support/access_control.exs", __DIR__


### PR DESCRIPTION
This adds the ability to use a custom crypto module to encrypt and validate passwords, instead of being forced to use `Comeonin.Pbkdf2` or `Comeonin.Bcrypt`.

This was added for my use case: I want to write an elixir app that allows logins from an existing django database.  I need an auth system that can validate the django passwords in the database, which were not hashed using the standard `Comeonin.Pbkdf2.hashpwsalt` or `Comeonin.Bcrypt.hashpwsalt` functions.

I'm new to Elixir and very open to feedback -- especially in regards to test coverage and test code.
