### PR TITLE
Adjust examples for authorize_action_role, fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tested with the Phoenix Web Framework.
   ```elixir
   defp deps do
     [{:openmaize, "~> 1.0.0"},
-    {:openmaize_jwt, "~> 0.12"]
+    {:openmaize_jwt, "~> 0.12"}]
   end
   ```
 

--- a/priv/templates/api/authorize.ex
+++ b/priv/templates/api/authorize.ex
@@ -63,7 +63,7 @@ defmodule <%= base %>.Authorize do
 
   First, import this module in the controller, and then add the following line:
 
-      def action(conn, _), do: authorize_action conn, ["admin", "user"], __MODULE__
+      def action(conn, _), do: authorize_action_role conn, ["admin", "user"], __MODULE__
 
   This command will only allow connections for users with the "admin" or "user"
   role.

--- a/priv/templates/html/authorize.ex
+++ b/priv/templates/html/authorize.ex
@@ -65,7 +65,7 @@ defmodule <%= base %>.Authorize do
 
   First, import this module in the controller, and then add the following line:
 
-      def action(conn, _), do: authorize_action conn, ["admin", "user"], __MODULE__
+      def action(conn, _), do: authorize_action_role conn, ["admin", "user"], __MODULE__
 
   This command will only allow connections for users with the "admin" or "user"
   role.


### PR DESCRIPTION
These are some small improvements of the doc string for authorize_action_role method as well as the README.
