### PR TITLE
Add support for enable/disable multiple logins with the same OTP

### DIFF
--- a/lib/openmaize/config.ex
+++ b/lib/openmaize/config.ex
@@ -5,12 +5,13 @@ defmodule Openmaize.Config do
   The following are valid configuration items.
 
 
-  | name               | type         | default          |
-  | :----------------- | :----------- | ---------------: |
-  | crypto_mod         | module       | Comeonin.Bcrypt  |
-  | hash_name          | atom         | :password_hash   |
-  | password_strength  | keyword list | []               |
-  | remember_salt      | string       | N/A              |
+  | name                      | type         | default          |
+  | :------------------------ | :----------- | ---------------: |
+  | crypto_mod                | module       | Comeonin.Bcrypt  |
+  | hash_name                 | atom         | :password_hash   |
+  | password_strength         | keyword list | []               |
+  | remember_salt             | string       | N/A              |
+  | allow_multiple_otp_logins | boolean      | false            |
 
   ## Examples
 
@@ -21,7 +22,8 @@ defmodule Openmaize.Config do
       config :openmaize,
         crypto_mod: Comeonin.Bcrypt,
         hash_name: :encrypted_password,
-        password_strength: [min_length: 12]
+        password_strength: [min_length: 12],
+        allow_multiple_otp_logins: false
 
   """
 
@@ -83,5 +85,12 @@ defmodule Openmaize.Config do
   """
   def remember_salt do
     Application.get_env(:openmaize, :remember_salt)
+  end
+
+  @doc """
+  Allows multiple logins with the same otp when set to true (default is false)
+  """
+  def allow_multiple_otp_logins do
+    Application.get_env(:openmaize, :allow_multiple_otp_logins, false)
   end
 end

--- a/lib/openmaize/database.ex
+++ b/lib/openmaize/database.ex
@@ -64,4 +64,25 @@ defmodule Openmaize.Database do
   """
   @callback check_time(Integer | nil, Integer) :: boolean
 
+
+  @doc """
+  This function check if an otp token is already stored in the database 
+  for a certain user id.
+
+  The first argument is the user id, the second argument is the otp token.
+
+  This function return :is_new if the token is not present in the database,
+  or :is_old if the token is already present in the database. 
+  """
+  @callback old_otp_token?(Integer, String.t) :: :is_new | :is_old
+
+
+  @doc """
+  Add the otp token to the database. 
+
+  The first argument is the user id, the second argument is the token.
+  """
+  @callback add_token_to_old_tokens(Integer, String.t) :: {:ok} | {:error}
+
+
 end

--- a/priv/templates/database/openmaize_ecto.ex
+++ b/priv/templates/database/openmaize_ecto.ex
@@ -156,4 +156,22 @@ defmodule <%= base %>.OpenmaizeEcto do
   defp reset_update_repo({:error, message}, _user) do
     {:error, message}
   end
+
+    def old_otp_token?(user_id, totp) do
+    # Try to load the record for the given user_id and token,
+    #   if it fails (nil), it means that the token is used for the first time,
+    #   else it means that the token was already used before.
+    result = Repo.get_by(OldOtpToken, user_id: user_id, token: totp)
+    case result do
+      nil -> :is_new
+      _   -> :is_old
+    end
+  end
+
+  def add_token_to_old_tokens(user_id, token) do
+    # Store the token in the database
+    Repo.insert!(%OldOtpToken{user_id: String.to_integer(user_id), token: token})
+  end
+
+
 end

--- a/test/support/ecto_db.exs
+++ b/test/support/ecto_db.exs
@@ -1,7 +1,7 @@
 defmodule Openmaize.EctoDB do
 
   import Ecto.Changeset
-  alias Openmaize.{TestRepo, TestUser}
+  alias Openmaize.{TestRepo, TestUser, TestOldOtpToken}
   alias Openmaize.{Config, Password}
 
   @behaviour Openmaize.Database
@@ -69,4 +69,23 @@ defmodule Openmaize.EctoDB do
   defp reset_update_repo({:error, message}, _user) do
     {:error, message}
   end
+
+  
+  def old_otp_token?(user_id, totp) do
+    # Try to load the record for the given user_id and token,
+    #   if it fails (nil), it means that the token is used for the first time,
+    #   else it means that the token was already used before.
+    result = TestRepo.get_by(TestOldOtpToken, user_id: user_id, token: totp)
+    case result do
+      nil -> :is_new
+      _   -> :is_old
+    end
+  end
+
+  def add_token_to_old_tokens(user_id, token) do
+    # Store the token in the database
+    TestRepo.insert!(%TestOldOtpToken{user_id: String.to_integer(user_id), token: token})
+  end
+
+
 end

--- a/test/support/ecto_helper.exs
+++ b/test/support/ecto_helper.exs
@@ -33,8 +33,14 @@ defmodule UsersMigration do
       add :otp_required, :boolean
       add :otp_secret, :string
     end
-
     create unique_index :users, [:email]
+
+    create table(:old_otp_tokens) do
+      add :token, :string
+      add :user_id, references(:users, on_delete: :nothing)
+    end
+    create index :old_otp_tokens, [:user_id]
+
   end
 end
 
@@ -84,3 +90,22 @@ defmodule Openmaize.TestUser do
     |> Openmaize.EctoDB.add_confirm_token(key)
   end
 end
+
+
+defmodule Openmaize.TestOldOtpToken do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "old_otp_tokens" do
+    field :user_id, :integer #belongs_to :user, Openmaize.TestUser
+    field :token, :string
+  end
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, [:user_id, :token ])
+    |> validate_required([:user_id, :token])
+  end
+end
+
+

--- a/test/support/setup_db.exs
+++ b/test/support/setup_db.exs
@@ -27,6 +27,12 @@ defmodule Openmaize.SetupDB do
     user5 = %{email: "brian@mail.com", username: "brian", role: "user", password: "h4rd2gU3$$",
               otp_required: true, otp_secret: "MFRGGZDFMZTWQ2LK"}
     {:ok, _} = %TestUser{} |> TestUser.auth_changeset(user5) |> TestRepo.insert
-  end
 
+
+    user6 = %{email: "master@mail.com", username: "master", role: "admin", password: "h4rd2gU3$$",
+              otp_required: true, otp_secret: "ZBTEKZDFMZTWQL6R"}
+    {:ok, _} = %TestUser{} 
+      |> TestUser.auth_changeset(user6) 
+      |> TestRepo.insert
+  end
 end


### PR DESCRIPTION
- Why this change is necessary?
  OTP Tokens shouldn't be never used again after their first validation,
  to prevent security holes. If a TOTP token is allowed to be used
  multiple times during it's lifetime, a man-in-the-middle attacker could
  use the eavesdropped token at the same time with the legitimate user,
  gaining access to the service but without the user nor the
  administrator can notice the fact.
  An OTP already used should be rejected, and the user alerted
  with an informative message saying to wait for the next token before
  entering again. The service administrator could log all the multiple
  attempts, and point out those access with the same token but
  coming from different IP.
- How does it address the problem?
  It adds a new item named :allow_multiple_otp_logins to the
  configuration file. When its value is false (default), the database
  is checked every time the user try to login with a valid OTP token.
  If the otp token is already present in the database, the token is
  rejected and the login will fail. Instead if the valid token was never
  used before, it is stored in the database, and the login will succeed.
- Are there any side effects?
  The database is updated every time a token is valid and never
  used before.
