### PR TITLE
Fix @changeset rererences in form templates

### DIFF
--- a/priv/templates/phoenixauth/password_reset_new.html.eex
+++ b/priv/templates/phoenixauth/password_reset_new.html.eex
@@ -1,6 +1,6 @@
 <h2>Reset password</h2>
 
-<%= form_for @conn, password_reset_path(@conn, :create), [as: :password_reset], fn f -> %>
+<%= form_for @changeset, password_reset_path(@conn, :create), [as: :password_reset], fn f -> %>
   <%= if f.errors != [] do %>
     <div class="alert alert-danger">
       <p>Please check the errors below:</p>

--- a/priv/templates/phoenixauth/user_new.html.eex
+++ b/priv/templates/phoenixauth/user_new.html.eex
@@ -1,6 +1,6 @@
 <h2>New user</h2>
 
-<%= form_for @conn, user_path(@conn, :create), [as: :user], fn f -> %>
+<%= form_for @changeset, user_path(@conn, :create), [as: :user], fn f -> %>
   <%= if f.errors != [] do %>
     <div class="alert alert-danger">
       <p>Please check the errors below:</p>


### PR DESCRIPTION
An incorrect reference to `@conn` instead of `@changeset` in the `new_user` and in the `reset_password` templates prevents to display the error messages when a  user enter a not valid string in the fields of these forms.