### PR TITLE
Fixes form_for helper arguments for generated PasswordReset views

### DIFF
--- a/installer/phoenix/templates/phx_html/password_reset_edit.html.eex
+++ b/installer/phoenix/templates/phx_html/password_reset_edit.html.eex
@@ -1,6 +1,6 @@
 <h2>Reset password</h2>
 
-<%= form_for @conn, password_reset_path(@conn, :update, @user), [as: :password_reset], fn f -> %>
+<%= form_for @conn, password_reset_path(@conn, :update, @user), [as: :password_reset, method: :put], fn f -> %>
   <%= if f.errors != [] do %>
     <div class="alert alert-danger">
       <p>Please check the errors below:</p>

--- a/installer/phoenix/templates/phx_html/password_reset_new.html.eex
+++ b/installer/phoenix/templates/phx_html/password_reset_new.html.eex
@@ -1,6 +1,6 @@
 <h2>Reset password</h2>
 
-<%= form_for @changeset, password_reset_path(@conn, :create), [as: :password_reset], fn f -> %>
+<%= form_for @conn, password_reset_path(@conn, :create), [as: :password_reset], fn f -> %>
   <%= if f.errors != [] do %>
     <div class="alert alert-danger">
       <p>Please check the errors below:</p>


### PR DESCRIPTION
Hi there,

first of all thank you very much for this great lib! I really appreciate the work you put in here and it is fun to use!

I just faced some problems trying to implement the password reset feature with the generated  controllers and templates. This is my approach for a solution.

* The `PasswordResetController.new/2` function does not set a changeset, so I think the view should use the `@conn` instead of `@changeset`.
* The `form_for` function in the `edit` template needs to have the method explicitly set, otherwise it will try to send a `POST` request.

Please let me know what you think.

Best,
Christian